### PR TITLE
Fix circuit behavior for non-consecutive failures.

### DIFF
--- a/lib/simple_circuit_breaker.rb
+++ b/lib/simple_circuit_breaker.rb
@@ -24,18 +24,12 @@ protected
 
   def execute(exceptions, &block)
     begin
-      yield.tap { success! }
+      yield.tap { reset! }
     rescue Exception => exception
       if exceptions.empty? || exceptions.include?(exception.class)
         fail!
       end
       raise
-    end
-  end
-
-  def success!
-    if @state == :half_open
-      reset!
     end
   end
 
@@ -53,16 +47,7 @@ protected
   end
 
   def tripped?
-    @state != :closed && !try_to_close
-  end
-
-  def try_to_close
-    if timeout_exceeded?
-      @state = :half_open
-      true
-    else
-      false
-    end
+    @state == :open && !timeout_exceeded?
   end
 
   def timeout_exceeded?

--- a/test/simple_circuit_breaker_test.rb
+++ b/test/simple_circuit_breaker_test.rb
@@ -73,6 +73,16 @@ describe SimpleCircuitBreaker do
         end
       end
     end
+
+    it 'doesn\'t open after 3 non-consecutive failures for handled exception' do
+      4.times do
+        begin
+          @breaker.handle(RuntimeError) {}
+          @breaker.handle(RuntimeError) { raise RuntimeError }
+        rescue RuntimeError
+        end
+      end
+    end
   end
 
   describe 'opened circuit' do


### PR DESCRIPTION
This fixes handling for non-consecutive failures, which should not cause
the circuit to open. Upon every successul block execution, it now resets
the failure counter to 0. That also means that the "half_open" state
becomes completely unneeded and the "tripped?" check becomes much
simpler and easier to understand as a result.
