### PR TITLE
Fix #handle for BasicObject return values

### DIFF
--- a/lib/simple_circuit_breaker.rb
+++ b/lib/simple_circuit_breaker.rb
@@ -23,14 +23,14 @@ class SimpleCircuitBreaker
 protected
 
   def execute(exceptions, &block)
-    begin
-      yield.tap { reset! }
-    rescue Exception => exception
-      if exceptions.empty? || exceptions.include?(exception.class)
-        fail!
-      end
-      raise
+    result = yield
+    reset!
+    result
+  rescue Exception => exception
+    if exceptions.empty? || exceptions.include?(exception.class)
+      fail!
     end
+    raise
   end
 
   def fail!

--- a/test/simple_circuit_breaker_test.rb
+++ b/test/simple_circuit_breaker_test.rb
@@ -32,6 +32,15 @@ describe SimpleCircuitBreaker do
       foo.must_equal 42
     end
 
+    it 'works with BasicObject return values' do
+      object = BasicObject.new
+      foo = @breaker.handle do
+        object
+      end
+
+      assert foo.equal?(object)
+    end
+
     it 'opens after 3 consecutive failures with no explicit handled exceptions' do
       3.times do
         begin


### PR DESCRIPTION
We want to wrap calls to redis with `SimpleCurcuitBreaker#handle`. Pipelined requests return `Redis::Future` objects that are derived from `BasicObject` and therefore don't respond to `#tap` resulting in a `NoMethodError` in `#handle`. Note that minitest's `#must_equal` also doesn't work, but at least `#equal?` does. 