### PR TITLE
Handle subclasses of exceptions as fail! condition

### DIFF
--- a/lib/simple_circuit_breaker.rb
+++ b/lib/simple_circuit_breaker.rb
@@ -26,8 +26,8 @@ protected
     result = yield
     reset!
     result
-  rescue Exception => exception
-    if exceptions.empty? || exceptions.include?(exception.class)
+  rescue Exception => e
+    if exceptions.empty? || exceptions.any? { |exception| e.class <= exception }
       fail!
     end
     raise

--- a/test/simple_circuit_breaker_test.rb
+++ b/test/simple_circuit_breaker_test.rb
@@ -71,6 +71,23 @@ describe SimpleCircuitBreaker do
       end.must_raise SimpleCircuitBreaker::CircuitOpenError
     end
 
+    it 'opens after 3 consecutive failures for subclasses of a handled exception' do
+      subclass = Class.new(StandardError)
+
+      3.times do
+        begin
+          @breaker.handle(StandardError) { raise subclass }
+        rescue subclass
+        end
+      end
+
+      Proc.new do
+        @breaker.handle(StandardError) do
+          raise subclass
+        end
+      end.must_raise SimpleCircuitBreaker::CircuitOpenError
+    end
+
     it 'doesn\'t open after 3 consecutive failures for non-handled exception' do
       class FooError < Exception
       end


### PR DESCRIPTION
This is useful for handling a base class of exceptions rather than needing to enumerate all possible types when calling `SimpleCircuitBreaker#handle`.